### PR TITLE
feat: Add defensive attributes (#@ascii_only, strict limits, #@Sealed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,14 @@ code_quality_report.html
 
 # Claude Code (user-specific)
 .claude/
+tmpclaude-*
+
+# Auto-generated linter config
+gdlint.json
+gdlint-custom.json
+
+# Local documentation/plans
+docs/
+
+# Benchmark test files
+temp/

--- a/addons/gdscript-linter/CLI.md
+++ b/addons/gdscript-linter/CLI.md
@@ -68,42 +68,42 @@ Example `gdlint.json`:
 
 ```json
 {
-    "limits": {
-        "file_lines_soft": 200,
-        "file_lines_hard": 300,
-        "function_lines": 30,
-        "function_lines_critical": 60,
-        "max_parameters": 4,
-        "max_nesting": 3,
-        "cyclomatic_warning": 10,
-        "cyclomatic_critical": 15
-    },
-    "checks": {
-        "file_length": true,
-        "function_length": true,
-        "parameters": true,
-        "nesting": true,
-        "todo_comments": true,
-        "long_lines": true,
-        "print_statements": true,
-        "empty_functions": true,
-        "magic_numbers": true,
-        "commented_code": true,
-        "missing_types": true,
-        "cyclomatic_complexity": true,
-        "god_class": true,
-        "naming_conventions": true,
-        "unused_variables": true,
-        "unused_parameters": true,
-        "missing_return_type": true
-    },
-    "scanning": {
-        "respect_gdignore": true,
-        "scan_addons": false
-    },
-    "exclude": {
-        "paths": ["addons/", ".godot/", "tests/mocks/"]
-    }
+	"limits": {
+		"file_lines_soft": 200,
+		"file_lines_hard": 300,
+		"function_lines": 30,
+		"function_lines_critical": 60,
+		"max_parameters": 4,
+		"max_nesting": 3,
+		"cyclomatic_warning": 10,
+		"cyclomatic_critical": 15
+	},
+	"checks": {
+		"file_length": true,
+		"function_length": true,
+		"parameters": true,
+		"nesting": true,
+		"todo_comments": true,
+		"long_lines": true,
+		"print_statements": true,
+		"empty_functions": true,
+		"magic_numbers": true,
+		"commented_code": true,
+		"missing_types": true,
+		"cyclomatic_complexity": true,
+		"god_class": true,
+		"naming_conventions": true,
+		"unused_variables": true,
+		"unused_parameters": true,
+		"missing_return_type": true
+	},
+	"scanning": {
+		"respect_gdignore": true,
+		"scan_addons": false
+	},
+	"exclude": {
+		"paths": ["addons/", ".godot/", "tests/mocks/"]
+	}
 }
 ```
 
@@ -171,18 +171,18 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+	runs-on: ubuntu-latest
+	steps:
+	  - uses: actions/checkout@v4
 
-      - name: Setup Godot
-        uses: chickensoft-games/setup-godot@v1
-        with:
-          version: 4.2.1
+	  - name: Setup Godot
+		uses: chickensoft-games/setup-godot@v1
+		with:
+		  version: 4.2.1
 
-      - name: Run GDScript Linter
-        run: |
-          godot --headless --script res://addons/gdscript-linter/analyzer/analyze-cli.gd -- --format github
+	  - name: Run GDScript Linter
+		run: |
+		  godot --headless --script res://addons/gdscript-linter/analyzer/analyze-cli.gd -- --format github
 ```
 
 ### GitLab CI
@@ -191,10 +191,10 @@ jobs:
 lint:
   image: barichello/godot-ci:4.2.1
   script:
-    - godot --headless --script res://addons/gdscript-linter/analyzer/analyze-cli.gd -- --format json > lint-report.json
+	- godot --headless --script res://addons/gdscript-linter/analyzer/analyze-cli.gd -- --format json > lint-report.json
   artifacts:
-    reports:
-      codequality: lint-report.json
+	reports:
+	  codequality: lint-report.json
 ```
 
 ## Examples
@@ -233,11 +233,11 @@ godot --headless --script ... -- --check high-complexity,long-function
 ```bash
 # Strict CI check: critical issues only, specific checks, GitHub annotations
 godot --headless --script ... -- \
-    --config gdlint-ci.json \
-    --severity critical \
-    --check high-complexity,long-function,god-class \
-    --format github \
-    src/
+	--config gdlint-ci.json \
+	--severity critical \
+	--check high-complexity,long-function,god-class \
+	--format github \
+	src/
 ```
 
 ## Available Check IDs

--- a/addons/gdscript-linter/IGNORE_RULES.md
+++ b/addons/gdscript-linter/IGNORE_RULES.md
@@ -113,6 +113,57 @@ func branchy_logic() -> void:
 
 This helps you catch regressions while still allowing intentional exceptions to your normal limits.
 
+## Defensive Attributes
+
+### `#@ascii_only` — ASCII Enforcement
+
+Place `#@ascii_only` in the first 10 lines of a file to enforce ASCII-only characters throughout the entire file (including strings and comments).
+
+```gdscript
+#@ascii_only
+class_name MyScript
+extends Node
+
+var name := "hello"  # OK
+var label := "héllo"  # WARNING: ascii-violation
+```
+
+Enable project-wide ASCII enforcement via config: `ascii_only_project_wide = true`. Individual files can opt out with `# gdlint:ignore-file:ascii-violation`.
+
+### `# gdlint:strict` — Tighter Per-Scope Limits
+
+Override global thresholds with stricter limits. Issues fire at CRITICAL severity. When a strict directive exists for a rule, the normal threshold check is suppressed.
+
+**File-scoped** (first 10 lines):
+```gdscript
+# gdlint:strict-file:file-length=200
+# gdlint:strict-file:god-class-functions=10
+extends Node
+```
+
+**Function-scoped** (above func declaration):
+```gdscript
+# gdlint:strict-function:long-function=25
+# gdlint:strict-function:high-complexity=8
+func critical_function():
+    pass
+```
+
+**Supported rules:** `long-function`, `file-length`, `high-complexity`, `deep-nesting`, `too-many-params`, `god-class-functions`, `god-class-signals`
+
+### `#@Sealed` — Prevent Class Inheritance
+
+Mark a class as sealed to prevent other files from extending it. Requires `class_name` on the next line. Only works with directory-wide analysis (not single-file).
+
+```gdscript
+#@Sealed
+class_name CoreAPI
+extends RefCounted
+# Other files that try "extends CoreAPI" will get a CRITICAL sealed-violation
+```
+
+Place `#@Sealed` in the first 10 lines, immediately before `class_name`. Path-based extends (`extends "res://..."`) is not checked in v1.
+
 ## Common Rule Names
 
 | Rule ID | Description |
@@ -127,4 +178,7 @@ This helps you catch regressions while still allowing intentional exceptions to 
 | `missing-type` | Missing type annotation |
 | `unused-variable` | Variable declared but never used |
 | `unused-parameter` | Parameter declared but never used |
+| `ascii-violation` | Non-ASCII character in #@ascii_only file |
+| `strict-limit` | Value exceeds gdlint:strict limit |
+| `sealed-violation` | Extends a #@Sealed class |
 

--- a/addons/gdscript-linter/analyzer/analysis-config.gd
+++ b/addons/gdscript-linter/analyzer/analysis-config.gd
@@ -36,6 +36,10 @@ extends Resource
 @export var check_unused_parameters: bool = true
 @export var check_missing_return_type: bool = true  # Public functions without return type annotation
 @export var ignore_underscore_prefix: bool = true  # Skip _var names as intentionally unused
+@export var check_ascii_only: bool = true          # Enable #@ascii_only per-file attribute
+@export var ascii_only_project_wide: bool = false   # When true, all files checked for ASCII
+@export var check_strict_limits: bool = true        # Enable gdlint:strict directives
+@export var check_sealed: bool = true               # Enable #@Sealed class protection
 
 # Scanning options
 @export var respect_gdignore: bool = true  # Skip directories containing .gdignore files
@@ -158,6 +162,10 @@ func _apply_checks_value(key: String, value: String) -> void:
 		"missing_return_type": check_missing_return_type = enabled
 		"ignore_underscore_prefix": ignore_underscore_prefix = enabled
 		"respect_gdignore": respect_gdignore = enabled
+		"ascii_only": check_ascii_only = enabled
+		"ascii_only_project_wide": ascii_only_project_wide = enabled
+		"strict_limits": check_strict_limits = enabled
+		"sealed": check_sealed = enabled
 
 
 func _apply_exclude_value(key: String, value: String) -> void:
@@ -215,6 +223,10 @@ func save_to_json(path: String) -> bool:
 			"unused_parameters": check_unused_parameters,
 			"missing_return_type": check_missing_return_type,
 			"ignore_underscore_prefix": ignore_underscore_prefix,
+			"ascii_only": check_ascii_only,
+			"ascii_only_project_wide": ascii_only_project_wide,
+			"strict_limits": check_strict_limits,
+			"sealed": check_sealed,
 		},
 		"scanning": {
 			"respect_gdignore": respect_gdignore,
@@ -300,6 +312,10 @@ func load_from_json(path: String) -> bool:
 		if checks.has("unused_parameters"): check_unused_parameters = bool(checks.unused_parameters)
 		if checks.has("missing_return_type"): check_missing_return_type = bool(checks.missing_return_type)
 		if checks.has("ignore_underscore_prefix"): ignore_underscore_prefix = bool(checks.ignore_underscore_prefix)
+		if checks.has("ascii_only"): check_ascii_only = bool(checks.ascii_only)
+		if checks.has("ascii_only_project_wide"): ascii_only_project_wide = bool(checks.ascii_only_project_wide)
+		if checks.has("strict_limits"): check_strict_limits = bool(checks.strict_limits)
+		if checks.has("sealed"): check_sealed = bool(checks.sealed)
 
 	# Apply scanning options
 	if data.has("scanning"):

--- a/addons/gdscript-linter/analyzer/analyze-cli.gd
+++ b/addons/gdscript-linter/analyzer/analyze-cli.gd
@@ -229,6 +229,9 @@ func _apply_check_filter_to_config(config: Resource) -> void:
 		"naming-enum": "check_naming_conventions",
 		"unused-variable": "check_unused_variables",
 		"unused-parameter": "check_unused_parameters",
+		"ascii-violation": "check_ascii_only",
+		"strict-limit": "check_strict_limits",
+		"sealed-violation": "check_sealed",
 	}
 
 	# Disable all checks first

--- a/addons/gdscript-linter/analyzer/checkers/attribute-checker.gd
+++ b/addons/gdscript-linter/analyzer/checkers/attribute-checker.gd
@@ -1,0 +1,44 @@
+# GDScript Linter - Custom attribute checker
+# Handles #@ascii_only file attribute detection and ASCII validation
+# https://poplava.itch.io
+class_name GDLintAttributeChecker
+extends RefCounted
+
+var config
+
+const SCAN_LIMIT := 10  # Only scan first 10 lines for attributes
+
+
+func _init(p_config) -> void:
+	config = p_config
+
+
+# Scan first 10 lines for #@ascii_only attribute
+func has_ascii_only_attribute(lines: Array) -> bool:
+	var max_lines := mini(SCAN_LIMIT, lines.size())
+	for i in range(max_lines):
+		if lines[i].strip_edges() == "#@ascii_only":
+			return true
+	return false
+
+
+# Check all lines for non-ASCII characters, returns array of issue dicts
+func check_ascii(lines: Array) -> Array:
+	var issues: Array = []
+	var regex := RegEx.new()
+	regex.compile("[^\\x00-\\x7F]")
+
+	for i in range(lines.size()):
+		var line: String = lines[i]
+		var result := regex.search(line)
+		if result:
+			var char_found: String = result.get_string()
+			var codepoint := char_found.unicode_at(0)
+			var line_num := i + 1
+			issues.append({
+				"line": line_num,
+				"severity": "warning",
+				"check_id": "ascii-violation",
+				"message": "Non-ASCII character found: U+%04X" % codepoint
+			})
+	return issues

--- a/addons/gdscript-linter/analyzer/checkers/attribute-checker.gd.uid
+++ b/addons/gdscript-linter/analyzer/checkers/attribute-checker.gd.uid
@@ -1,0 +1,1 @@
+uid://cxy61e36vbpvf

--- a/addons/gdscript-linter/analyzer/strict-handler.gd
+++ b/addons/gdscript-linter/analyzer/strict-handler.gd
@@ -1,0 +1,129 @@
+# GDScript Linter - Strict directive handler
+# Handles gdlint:strict-function and gdlint:strict-file directives
+# https://poplava.itch.io
+class_name GDLintStrictHandler
+extends RefCounted
+## Parses and queries gdlint:strict-* directives for tighter per-scope limits
+
+const STRICT_FUNCTION_PATTERN := "gdlint:strict-function"
+const STRICT_FILE_PATTERN := "gdlint:strict-file"
+const SCAN_LIMIT := 10  # Only scan first 10 lines for file-level directives
+
+# Regex pattern: gdlint:strict-(function|file):check-id=value
+const STRICT_REGEX_PATTERN := "gdlint:strict-(?:function|file):(\\w[\\w-]*)=(\\d+)"
+
+# Parsed data
+var _file_strict_limits: Dictionary = {}     # check_id -> limit value (file-scope)
+var _function_strict_ranges: Array = []       # [{start: int, end: int, check_id: String, limit: int}]
+
+
+func initialize(lines: Array) -> void:
+	clear()
+	_parse_file_strict(lines)
+	_parse_function_strict(lines)
+
+
+func clear() -> void:
+	_file_strict_limits = {}
+	_function_strict_ranges = []
+
+
+# Returns strict limit for a check at a given line, or -1 if none
+# File-scope overrides function-scope
+func get_strict_limit(line_num: int, check_id: String) -> int:
+	# File-scope first (higher priority)
+	if _file_strict_limits.has(check_id):
+		return _file_strict_limits[check_id]
+
+	# Function-scope
+	for range_entry in _function_strict_ranges:
+		if line_num >= range_entry.start and line_num <= range_entry.end:
+			if range_entry.check_id == check_id:
+				return range_entry.limit
+
+	return -1
+
+
+# Parse file-level strict directives from first 10 lines
+func _parse_file_strict(lines: Array) -> void:
+	var max_lines := mini(SCAN_LIMIT, lines.size())
+	for i in range(max_lines):
+		var line: String = lines[i]
+		if STRICT_FILE_PATTERN not in line:
+			continue
+		var parsed := _extract_strict_directive(line, STRICT_FILE_PATTERN)
+		if parsed.check_id != "" and parsed.limit >= 0:
+			_file_strict_limits[parsed.check_id] = parsed.limit
+
+
+# Parse function-level strict directives for all lines
+func _parse_function_strict(lines: Array) -> void:
+	for i in range(lines.size()):
+		var line: String = lines[i]
+		if STRICT_FUNCTION_PATTERN not in line:
+			continue
+		var parsed := _extract_strict_directive(line, STRICT_FUNCTION_PATTERN)
+		if parsed.check_id == "" or parsed.limit < 0:
+			continue
+		var func_range := _find_function_range(lines, i)
+		if func_range.start > 0:
+			_function_strict_ranges.append({
+				"start": func_range.start,
+				"end": func_range.end,
+				"check_id": parsed.check_id,
+				"limit": parsed.limit
+			})
+
+
+# Extract check_id and limit from a strict directive
+# e.g., "# gdlint:strict-function:long-function=25" -> {check_id: "long-function", limit: 25}
+func _extract_strict_directive(line: String, pattern: String) -> Dictionary:
+	var pos := line.find(pattern)
+	if pos < 0:
+		return {"check_id": "", "limit": -1}
+
+	var after := line.substr(pos + pattern.length())
+	if not after.begins_with(":"):
+		return {"check_id": "", "limit": -1}
+
+	var directive_str := after.substr(1).split(" ")[0].split("\t")[0].strip_edges()
+
+	var equals_pos := directive_str.find("=")
+	if equals_pos <= 0:
+		return {"check_id": "", "limit": -1}
+
+	var check_id := directive_str.substr(0, equals_pos)
+	var value_str := directive_str.substr(equals_pos + 1)
+	var limit := value_str.to_int() if value_str.is_valid_int() else -1
+
+	return {"check_id": check_id, "limit": limit}
+
+
+# Find the range of a function starting after the given line index
+# Replicates the pattern from ignore-handler.gd
+func _find_function_range(lines: Array, start_idx: int) -> Dictionary:
+	var func_start := -1
+	var func_end := -1
+
+	# Find the next func declaration after the strict comment
+	for i in range(start_idx + 1, lines.size()):
+		var trimmed: String = lines[i].strip_edges()
+		if trimmed.begins_with("func "):
+			func_start = i + 1  # Convert to 1-based line number
+			break
+
+	if func_start < 0:
+		return {"start": -1, "end": -1}
+
+	# Find where the function ends (next func or end of file)
+	for i in range(func_start, lines.size()):
+		var trimmed: String = lines[i].strip_edges()
+		if trimmed.begins_with("func "):
+			func_end = i  # Line before next func
+			break
+
+	# If no next function found, function extends to end of file
+	if func_end < 0:
+		func_end = lines.size()
+
+	return {"start": func_start, "end": func_end}

--- a/addons/gdscript-linter/analyzer/strict-handler.gd.uid
+++ b/addons/gdscript-linter/analyzer/strict-handler.gd.uid
@@ -1,0 +1,1 @@
+uid://dkaemcda6jglo

--- a/addons/gdscript-linter/dock.gd
+++ b/addons/gdscript-linter/dock.gd
@@ -28,7 +28,10 @@ const ISSUE_TYPES := {
 	"naming-const": "Naming: Constant",
 	"naming-enum": "Naming: Enum",
 	"unused-variable": "Unused Variable",
-	"unused-parameter": "Unused Parameter"
+	"unused-parameter": "Unused Parameter",
+	"ascii-violation": "ASCII Violation",
+	"strict-limit": "Strict Limit",
+	"sealed-violation": "Sealed Violation"
 }
 
 # Preload scripts

--- a/addons/gdscript-linter/ui/help-card-builder.gd
+++ b/addons/gdscript-linter/ui/help-card-builder.gd
@@ -10,6 +10,8 @@ class_name GDLintHelpCardBuilder
 func create_card_content(container: VBoxContainer) -> void:
 	_add_ignore_rules_section(container)
 	_add_separator(container)
+	_add_defensive_attributes_section(container)
+	_add_separator(container)
 	_add_cli_section(container)
 	_add_separator(container)
 	_add_shortcuts_section(container)
@@ -48,6 +50,58 @@ func _add_code_block(parent: VBoxContainer, code: String) -> void:
 	code_label.add_theme_color_override("font_color", Color(0.7, 0.8, 0.6))
 	code_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	parent.add_child(code_label)
+
+
+func _add_defensive_attributes_section(parent: VBoxContainer) -> void:
+	_add_section_header(parent, "Defensive Attributes", "Enforce stricter rules on specific files or functions")
+
+	# Summary table
+	_add_defensive_table(parent)
+
+	# Examples for each directive
+	_add_thin_separator(parent)
+	_add_ignore_example(parent, "#@ascii_only (per-file)",
+		"#@ascii_only\n# Place in first 10 lines. Raises ascii-violation WARNING\n# for any non-ASCII characters in the file.\n# Also available: ascii_only_project_wide in config")
+
+	_add_thin_separator(parent)
+	_add_ignore_example(parent, "gdlint:strict-file:rule=value",
+		"# gdlint:strict-file:long-function=20\n# Place in first 10 lines. Applies stricter limit to all\n# functions in the file. Raises strict-limit CRITICAL.")
+
+	_add_thin_separator(parent)
+	_add_ignore_example(parent, "gdlint:strict-function:rule=value",
+		"# gdlint:strict-function:long-function=15\nfunc tight_func():\n    # Applies stricter limit to this function only.\n    # Raises strict-limit CRITICAL. Suppresses normal check.")
+
+	_add_thin_separator(parent)
+	_add_ignore_example(parent, "#@Sealed (prevent inheritance)",
+		"#@Sealed\nclass_name MyBaseClass\n# Requires class_name on next line. Raises sealed-violation\n# CRITICAL when another file extends a sealed class.")
+
+
+func _add_defensive_table(parent: VBoxContainer) -> void:
+	var grid := GridContainer.new()
+	grid.columns = 2
+	grid.add_theme_constant_override("h_separation", 20)
+	grid.add_theme_constant_override("v_separation", 2)
+	parent.add_child(grid)
+
+	var directives := [
+		["#@ascii_only", "ASCII enforcement (WARNING)"],
+		["gdlint:strict-file:rule=val", "File-level strict limit (CRITICAL)"],
+		["gdlint:strict-function:rule=val", "Function-level strict limit (CRITICAL)"],
+		["#@Sealed", "Prevent inheritance (CRITICAL)"],
+	]
+
+	for entry in directives:
+		var directive_label := Label.new()
+		directive_label.text = entry[0]
+		directive_label.add_theme_font_size_override("font_size", 12)
+		directive_label.add_theme_color_override("font_color", Color(0.7, 0.8, 0.6))
+		grid.add_child(directive_label)
+
+		var scope_label := Label.new()
+		scope_label.text = entry[1]
+		scope_label.add_theme_font_size_override("font_size", 12)
+		scope_label.add_theme_color_override("font_color", Color(0.55, 0.57, 0.6))
+		grid.add_child(scope_label)
 
 
 func _add_ignore_rules_section(parent: VBoxContainer) -> void:

--- a/addons/gdscript-linter/ui/settings-card-builder.gd
+++ b/addons/gdscript-linter/ui/settings-card-builder.gd
@@ -247,6 +247,16 @@ func create_code_checks_card(controls: Dictionary) -> GDLintCollapsibleCard:
 	controls.check_unused_parameters = _add_check_to_grid(struct_grid, "Unused Parameters",
 		"Function parameters never used")
 
+	# Defensive section
+	_add_section_header(vbox, "Defensive")
+	var def_grid := _create_check_grid(vbox)
+	controls.check_ascii_only = _add_check_to_grid(def_grid, "ASCII Only",
+		"Enforce ASCII-only in attributed files")
+	controls.check_strict_limits = _add_check_to_grid(def_grid, "Strict Limits",
+		"Enforce stricter thresholds via directives")
+	controls.check_sealed = _add_check_to_grid(def_grid, "Sealed Classes",
+		"Prevent inheritance of sealed classes")
+
 	return card
 
 

--- a/addons/gdscript-linter/ui/settings-manager.gd
+++ b/addons/gdscript-linter/ui/settings-manager.gd
@@ -78,6 +78,9 @@ var check_file_length: bool = true
 var check_god_class: bool = true
 var check_unused_variables: bool = true
 var check_unused_parameters: bool = true
+var check_ascii_only: bool = true
+var check_strict_limits: bool = true
+var check_sealed: bool = true
 
 # Settings state - Claude Code
 var claude_code_enabled: bool = false
@@ -91,7 +94,8 @@ var _check_control_keys: Array[String] = [
 	"check_missing_types", "check_function_length", "check_parameters",
 	"check_nesting", "check_cyclomatic_complexity", "check_empty_functions",
 	"check_missing_return_type", "check_file_length", "check_god_class",
-	"check_unused_variables", "check_unused_parameters"
+	"check_unused_variables", "check_unused_parameters",
+	"check_ascii_only", "check_strict_limits", "check_sealed"
 ]
 
 # References
@@ -179,6 +183,9 @@ func _load_check_settings(editor_settings: EditorSettings) -> void:
 		"god_class": "check_god_class",
 		"unused_variables": "check_unused_variables",
 		"unused_parameters": "check_unused_parameters",
+		"ascii_only": "check_ascii_only",
+		"strict_limits": "check_strict_limits",
+		"sealed": "check_sealed",
 	}
 
 	for key_suffix: String in check_mappings:
@@ -233,6 +240,10 @@ func _apply_to_ui() -> void:
 		"check_god_class": func(): return check_god_class,
 		"check_unused_variables": func(): return check_unused_variables,
 		"check_unused_parameters": func(): return check_unused_parameters,
+		# Code checks - Defensive
+		"check_ascii_only": func(): return check_ascii_only,
+		"check_strict_limits": func(): return check_strict_limits,
+		"check_sealed": func(): return check_sealed,
 		# Claude Code
 		"claude_enabled_check": func(): return claude_code_enabled,
 	}
@@ -537,6 +548,9 @@ func _connect_check_signals() -> void:
 		"check_god_class": "god_class",
 		"check_unused_variables": "unused_variables",
 		"check_unused_parameters": "unused_parameters",
+		"check_ascii_only": "ascii_only",
+		"check_strict_limits": "strict_limits",
+		"check_sealed": "sealed",
 	}
 
 	for control_key in check_mappings:


### PR DESCRIPTION
## Summary
- **`#@ascii_only`** — Per-file ASCII enforcement. Raises `ascii-violation` WARNING for non-ASCII characters. Also supports `ascii_only_project_wide` config option.
- **`gdlint:strict-file:rule=value` / `gdlint:strict-function:rule=value`** — Tighter thresholds via directives. Raises `strict-limit` CRITICAL when exceeded, suppresses the normal check.
- **`#@Sealed`** — Prevents inheritance of classes marked with `#@Sealed` + `class_name`. Raises `sealed-violation` CRITICAL via two-pass directory analysis.

### What's included
- `attribute-checker.gd` — New checker for ASCII and Sealed validation
- `strict-handler.gd` — Handles strict directive parsing and threshold enforcement
- `code-analyzer.gd` — Orchestration for all 3 defensive checks
- `analysis-config.gd` — Config properties, JSON save/load, INI toggle support
- `analyze-cli.gd` — CLI check_id→property mappings
- `dock.gd` — Issue type filter dropdown entries
- `settings-card-builder.gd` — "Defensive" section with 3 toggle checkboxes in Code Checks card
- `settings-manager.gd` — Full settings wiring (properties, load, apply, connect)
- `help-card-builder.gd` — "Defensive Attributes" documentation section with table and examples
- `IGNORE_RULES.md` / `CLI.md` — Updated documentation

## Test plan
- [ ] Open GDScript Linter dock → Settings → Code Checks: verify "Defensive" section with 3 checkboxes
- [ ] Toggle checks off/on → verify persistence after closing/reopening settings
- [ ] Enable All / Disable All buttons include the 3 new checks
- [ ] Settings → Help card: verify "Defensive Attributes" section with directive table and examples
- [ ] Scan files with `#@ascii_only` → verify `ascii-violation` issues appear
- [ ] Scan files with `gdlint:strict-file` / `gdlint:strict-function` → verify `strict-limit` issues
- [ ] Scan files with `#@Sealed` → verify `sealed-violation` when another file extends sealed class
- [ ] Disable `check_ascii_only` → rescan → verify ascii-violation results are removed